### PR TITLE
feat(props): add new

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -62,7 +62,10 @@ export interface VariantProps {
 
 export interface BoxSxProps extends BoxProps, SxProps {
   onClick?: (args?: any) => void
+  onSubmit?: (args?: any) => void
   ref?: any
+  role?: string
+  ariaLabel?: string
   children?: React.ReactNode
 }
 


### PR DESCRIPTION
### What
We can add the ARIA labels and roles to any component.

### Why
DX. To cater for WCAG.

### How
- Extend `BoxSxProps` which is the base props.