### PR TITLE
fix(Popup): add scroll

### DIFF
--- a/src/components/Popup.tsx
+++ b/src/components/Popup.tsx
@@ -26,6 +26,7 @@ const Overlay = styled(Box)<ConstrainedBoxProps>`
 const StyledPopup = styled(Box)<PopupProps>`
   max-width: ${({ mode }) => (mode === 'sized' ? 'calc(100% - 16px)' : '100%')};
   background: ${({ bg }) => (bg ? bgColours[bg] : 'white')};
+  overflow: scroll;
 `
 
 export const Popup: React.FC<PopupProps> = ({


### PR DESCRIPTION
### What
Users can scroll popup contents when those overflow the widow height.

### Why
UX.